### PR TITLE
Register interesting offset finder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "phpactor/container": "^1.0",
-        "phpactor/code-transform": "~0.1",
+        "phpactor/code-transform": "~0.2",
         "phpactor/class-to-file-extension": "~0.1",
         "phpactor/worse-reflection-extension": "^0.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,14 @@
     "require": {
         "phpactor/container": "^1.0",
         "phpactor/code-transform": "~0.1",
-        "phpactor/class-to-file-extension": "~0.1"
+        "phpactor/class-to-file-extension": "~0.1",
+        "phpactor/worse-reflection-extension": "^0.2"
     },
     "require-dev": {
         "phpactor/rpc-extension": "^0.1.0@dev",
-        "phpstan/phpstan": "~0.11.0",
-        "phpunit/phpunit": "~7.0",
-        "friendsofphp/php-cs-fixer": "~2.15.0",
+        "phpstan/phpstan": "^0.10",
+        "phpunit/phpunit": "^7.3",
+        "friendsofphp/php-cs-fixer": "^2.13",
         "phpactor/test-utils": "^1.0@dev"
     },
     "autoload": {

--- a/lib/CodeTransformExtension.php
+++ b/lib/CodeTransformExtension.php
@@ -16,7 +16,6 @@ use Phpactor\MapResolver\Resolver;
 use Phpactor\Extension\CodeTransform\Rpc\ClassInflectHandler;
 use Phpactor\Extension\CodeTransform\Rpc\ClassNewHandler;
 use Phpactor\Extension\CodeTransform\Rpc\TransformHandler;
-use Phpactor\WorseReflection\Core\Reflector\SourceCodeReflector;
 use RuntimeException;
 
 class CodeTransformExtension implements Extension


### PR DESCRIPTION
Hi,

So this PR will register the new finder created in https://github.com/phpactor/code-transform/pull/26
as a service.
Which will allow us to inject it to the ConextMenuHandler in https://github.com/phpactor/phpactor.

Just an note aside, I started a new job and they're using a git split strategy.
I don't know if you have already worked with something like that but the idea is to have all the code in the same place and split different parts in different repositories.
For instance the phpactor/phpactor project would contains a `packages` directory in which you would have a directory for each Phpactor's repositories (code-transform, worse-reflection, etc)
Allowing to work on every part of the project from only one repository.
Instead of jumping from one to another and playing with the composer.json to use a local repository and stuff like that.
I don't know how it behaves with forks but it might be worth looking into it in order to ease the workflow when working on features impacting more than one repository.

[EDIT] The CI will complain until https://github.com/phpactor/code-transform/pull/26 is merged
You might have to restart manually once it's done